### PR TITLE
Support timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,57 +1,44 @@
 'use strict';
 
-var https = require('https');
-var http = require('http');
+var request = require('request');
 
-https.globalAgent.maxSockets = 500;
-
-var GOOGLE_BOOKS_API_BASE = 'www.googleapis.com';
+var GOOGLE_BOOKS_API_BASE = 'https://www.googleapis.com';
 var GOOGLE_BOOKS_API_BOOK = '/books/v1/volumes';
 
-var OPENLIBRARY_API_BASE = 'openlibrary.org';
+var OPENLIBRARY_API_BASE = 'https://openlibrary.org';
 var OPENLIBRARY_API_BOOK = '/api/books';
 
-var WORLDCAT_API_BASE = 'xisbn.worldcat.org';
+var WORLDCAT_API_BASE = 'http://xisbn.worldcat.org';
 var WORLDCAT_API_BOOK = '/webservices/xid/isbn';
 
 function _resolveGoogle(isbn, callback) {
   var requestOptions = {
-    host: GOOGLE_BOOKS_API_BASE,
-    path: GOOGLE_BOOKS_API_BOOK + '?q=isbn:' + isbn
+    url: GOOGLE_BOOKS_API_BASE + GOOGLE_BOOKS_API_BOOK + '?q=isbn:' + isbn
   };
 
-  var request = https.request(requestOptions, function(response) {
+  request(requestOptions, function(error, response, body) {
+    if (error) {
+      return callback(error);
+    }
+
     if (response.statusCode !== 200) {
       return callback(new Error('wrong response code: ' + response.statusCode));
     }
 
-    var body = '';
-    response.on('data', function(chunk) {
-      body += chunk;
-    })
+    var books = JSON.parse(body);
 
-    response.on('end', function() {
-      var books = JSON.parse(body);
+    if (!books.totalItems) {
+      return callback(new Error('no books found with isbn: ' + isbn));
+    }
 
-      if (!books.totalItems) {
-        return callback(new Error('no books found with isbn: ' + isbn));
-      }
+    // In very rare circumstances books.items[0] is undefined (see #2)
+    if (!books.items || books.items.length === 0) {
+      return callback(new Error('no volume info found for book with isbn: ' + isbn));
+    }
 
-      // In very rare circumstances books.items[0] is undefined (see #2)
-      if (!books.items || books.items.length === 0) {
-        return callback(new Error('no volume info found for book with isbn: ' + isbn));
-      }
-
-      var book = books.items[0].volumeInfo;
-      return callback(null, book);
-    })
+    var book = books.items[0].volumeInfo;
+    return callback(null, book);
   });
-
-  request.on('error', function(err) {
-    return callback(err);
-  })
-
-  request.end();
 }
 
 function _resolveOpenLibrary(isbn, callback) {
@@ -111,37 +98,27 @@ function _resolveOpenLibrary(isbn, callback) {
   };
 
   var requestOptions = {
-    host: OPENLIBRARY_API_BASE,
-    path: OPENLIBRARY_API_BOOK + '?bibkeys=ISBN:' + isbn + '&format=json&jscmd=details'
+    url: OPENLIBRARY_API_BASE + OPENLIBRARY_API_BOOK + '?bibkeys=ISBN:' + isbn + '&format=json&jscmd=details'
   };
 
-  var request = https.request(requestOptions, function(response) {
+  request(requestOptions, function(error, response, body) {
+    if (error) {
+      return callback(error);
+    }
+
     if (response.statusCode !== 200) {
       return callback(new Error('wrong response code: ' + response.statusCode));
     }
 
-    var body = '';
-    response.on('data', function(chunk) {
-      body += chunk;
-    })
+    var books = JSON.parse(body);
+    var book = books['ISBN:' + isbn];
 
-    response.on('end', function() {
-      var books = JSON.parse(body);
-      var book = books['ISBN:' + isbn];
+    if (!book) {
+      return callback(new Error('no books found with isbn: ' + isbn));
+    }
 
-      if (!book) {
-        return callback(new Error('no books found with isbn: ' + isbn));
-      }
-
-      return callback(null, standardize(book));
-    })
+    return callback(null, standardize(book));
   });
-
-  request.on('error', function(err) {
-    return callback(err);
-  })
-
-  request.end();
 }
 
 function _resolveWorldcat(isbn, callback) {
@@ -184,38 +161,28 @@ function _resolveWorldcat(isbn, callback) {
   };
 
   var requestOptions = {
-    host: WORLDCAT_API_BASE,
-    path: WORLDCAT_API_BOOK + '/' + isbn + '?method=getMetadata&fl=*&format=json'
+    url: WORLDCAT_API_BASE + WORLDCAT_API_BOOK + '/' + isbn + '?method=getMetadata&fl=*&format=json'
   };
 
-  var request = http.request(requestOptions, function(response) {
+  request(requestOptions, function(error, response, body) {
+    if (error) {
+      return callback(error);
+    }
+
     if (response.statusCode !== 200) {
       return callback(new Error('wrong response code: ' + response.statusCode));
     }
 
-    var body = '';
-    response.on('data', function(chunk) {
-      body += chunk;
-    })
+    var books = JSON.parse(body);
 
-    response.on('end', function() {
-      var books = JSON.parse(body);
+    if (books.stat !== 'ok') {
+      return callback(new Error('no books found with isbn: ' + isbn));
+    }
 
-      if (books.stat !== 'ok') {
-        return callback(new Error('no books found with isbn: ' + isbn));
-      }
+    var book = books.list[0];
 
-      var book = books.list[0];
-
-      return callback(null, standardize(book));
-    })
+    return callback(null, standardize(book));
   });
-
-  request.on('error', function(err) {
-    return callback(err);
-  })
-
-  request.end();
 }
 
 // XXX refactor this code if more providers are added.

--- a/index.js
+++ b/index.js
@@ -44,10 +44,10 @@ var OPENLIBRARY_API_BOOK = '/api/books';
 var WORLDCAT_API_BASE = 'http://xisbn.worldcat.org';
 var WORLDCAT_API_BOOK = '/webservices/xid/isbn';
 
-function _resolveGoogle(isbn, callback) {
-  var requestOptions = Object.assign({
+function _resolveGoogle(isbn, options, callback) {
+  var requestOptions = Object.assign({}, defaultOptions, options, {
     url: GOOGLE_BOOKS_API_BASE + GOOGLE_BOOKS_API_BOOK + '?q=isbn:' + isbn
-  }, defaultOptions);
+  });
 
   request(requestOptions, function(error, response, body) {
     if (error) {
@@ -74,7 +74,7 @@ function _resolveGoogle(isbn, callback) {
   });
 }
 
-function _resolveOpenLibrary(isbn, callback) {
+function _resolveOpenLibrary(isbn, options, callback) {
 
   var standardize = function standardize(book) {
     var standardBook = {
@@ -130,9 +130,9 @@ function _resolveOpenLibrary(isbn, callback) {
     return standardBook;
   };
 
-  var requestOptions = Object.assign({
+  var requestOptions = Object.assign({}, defaultOptions, options, {
     url: OPENLIBRARY_API_BASE + OPENLIBRARY_API_BOOK + '?bibkeys=ISBN:' + isbn + '&format=json&jscmd=details'
-  }, defaultOptions);
+  });
 
   request(requestOptions, function(error, response, body) {
     if (error) {
@@ -154,7 +154,7 @@ function _resolveOpenLibrary(isbn, callback) {
   });
 }
 
-function _resolveWorldcat(isbn, callback) {
+function _resolveWorldcat(isbn, options, callback) {
 
   var standardize = function standardize(book) {
     var standardBook = {
@@ -193,9 +193,9 @@ function _resolveWorldcat(isbn, callback) {
     return standardBook;
   };
 
-  var requestOptions = Object.assign({
+  var requestOptions = Object.assign({}, defaultOptions, options, {
     url: WORLDCAT_API_BASE + WORLDCAT_API_BOOK + '/' + isbn + '?method=getMetadata&fl=*&format=json'
-  }, defaultOptions);
+  });
 
   request(requestOptions, function(error, response, body) {
     if (error) {
@@ -220,12 +220,15 @@ function _resolveWorldcat(isbn, callback) {
 
 // XXX refactor this code if more providers are added.
 
-function resolve(isbn, callback) {
-  _resolveGoogle(isbn, function(err, book) {
+function resolve(isbn) {
+  const options = arguments.length === 3 ? arguments[1] : null;
+  const callback = arguments.length === 3 ? arguments[2] : arguments[1];
+
+  _resolveGoogle(isbn, options, function(err, book) {
     if (err) {
-      return _resolveOpenLibrary(isbn, function (err, book) {
+      return _resolveOpenLibrary(isbn, options, function (err, book) {
         if (err) {
-          return _resolveWorldcat(isbn, callback);
+          return _resolveWorldcat(isbn, options, callback);
         }
         return callback(null, book);
       });

--- a/index.js
+++ b/index.js
@@ -2,6 +2,39 @@
 
 var request = require('request');
 
+var defaultOptions = {
+  poll: {
+    maxSockets: 500,
+  },
+  timeout: 5000
+};
+
+// https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+if (typeof Object.assign != 'function') {
+  Object.assign = function(target, varArgs) { // .length of function is 2
+    'use strict';
+    if (target == null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource != null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  };
+}
+
 var GOOGLE_BOOKS_API_BASE = 'https://www.googleapis.com';
 var GOOGLE_BOOKS_API_BOOK = '/books/v1/volumes';
 
@@ -12,9 +45,9 @@ var WORLDCAT_API_BASE = 'http://xisbn.worldcat.org';
 var WORLDCAT_API_BOOK = '/webservices/xid/isbn';
 
 function _resolveGoogle(isbn, callback) {
-  var requestOptions = {
+  var requestOptions = Object.assign({
     url: GOOGLE_BOOKS_API_BASE + GOOGLE_BOOKS_API_BOOK + '?q=isbn:' + isbn
-  };
+  }, defaultOptions);
 
   request(requestOptions, function(error, response, body) {
     if (error) {
@@ -97,9 +130,9 @@ function _resolveOpenLibrary(isbn, callback) {
     return standardBook;
   };
 
-  var requestOptions = {
+  var requestOptions = Object.assign({
     url: OPENLIBRARY_API_BASE + OPENLIBRARY_API_BOOK + '?bibkeys=ISBN:' + isbn + '&format=json&jscmd=details'
-  };
+  }, defaultOptions);
 
   request(requestOptions, function(error, response, body) {
     if (error) {
@@ -160,9 +193,9 @@ function _resolveWorldcat(isbn, callback) {
     return standardBook;
   };
 
-  var requestOptions = {
+  var requestOptions = Object.assign({
     url: WORLDCAT_API_BASE + WORLDCAT_API_BOOK + '/' + isbn + '?method=getMetadata&fl=*&format=json'
-  };
+  }, defaultOptions);
 
   request(requestOptions, function(error, response, body) {
     if (error) {

--- a/index.js
+++ b/index.js
@@ -9,32 +9,6 @@ var defaultOptions = {
   timeout: 5000
 };
 
-// https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
-if (typeof Object.assign != 'function') {
-  Object.assign = function(target, varArgs) { // .length of function is 2
-    'use strict';
-    if (target == null) { // TypeError if undefined or null
-      throw new TypeError('Cannot convert undefined or null to object');
-    }
-
-    var to = Object(target);
-
-    for (var index = 1; index < arguments.length; index++) {
-      var nextSource = arguments[index];
-
-      if (nextSource != null) { // Skip over if undefined or null
-        for (var nextKey in nextSource) {
-          // Avoid bugs when hasOwnProperty is shadowed
-          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-            to[nextKey] = nextSource[nextKey];
-          }
-        }
-      }
-    }
-    return to;
-  };
-}
-
 var GOOGLE_BOOKS_API_BASE = 'https://www.googleapis.com';
 var GOOGLE_BOOKS_API_BOOK = '/books/v1/volumes';
 

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "devDependencies": {
     "mocha": "^3.3.0",
     "nock": "^9.0.13"
+  },
+  "dependencies": {
+    "request": "^2.81.0"
   }
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -195,4 +195,83 @@ describe('ISBN Resolver', function() {
       done();
     })
   });
+
+  it('should timeout on long connections', function(done) {
+    var mockResponseGoogle = {
+      totalItems: 1,
+      items: [{
+        'volumeInfo': {
+          'title': 'Code Complete',
+          'authors': ['Steve McConnell']
+        }
+      }]
+    };
+
+    var mockResponseOpenLibrary = {}
+    mockResponseOpenLibrary['ISBN:' + MOCK_ISBN] = {
+      'info_url': 'https://openlibrary.org/books/OL1743093M/Book',
+      'preview_url': 'https://archive.org/details/whatsitallabouta00cain',
+      'thumbnail_url': 'https://covers.openlibrary.org/b/id/6739180-S.jpg',
+      'details': {
+        'number_of_pages': 521,
+        'subtitle': 'an autobiography',
+        'title': 'Book Title',
+        'languages': [
+          {
+            'key': '/languages/eng'
+          }
+        ],
+        'publishers': [
+          'Turtle Bay Books'
+        ],
+        'authors': [
+          {
+            'name': 'Michael Caine',
+            'key': '/authors/OL840869A'
+          }
+        ],
+        'publish_date': '1992',
+      },
+      'preview': 'borrow'
+    };
+
+    var mockResponseWorldcat = {
+      "stat":"ok",
+      "list":[{
+        "url":["http://www.worldcat.org/oclc/249645389?referer=xid"],
+        "publisher":"Turtle Bay Books",
+        "form":["BC", "DA"],
+        "lccn":["2004049981"],
+        "lang":"eng",
+        "city":"Redmond, Wash.",
+        "author":"Steve McConnell.",
+        "ed":"2. ed.",
+        "year":"1992",
+        "isbn":["0735619670"],
+        "title":"Book Title",
+        "oclcnum":["249645389", "301075365", "427465443"]
+      }]
+    };
+
+    nock(GOOGLE_BOOKS_API_BASE)
+        .get(GOOGLE_BOOKS_API_BOOK)
+        .socketDelay(10000)
+        .reply(200, JSON.stringify(mockResponseGoogle));
+
+    nock(OPENLIBRARY_API_BASE)
+        .get(OPENLIBRARY_API_BOOK)
+        .socketDelay(10000)
+        .reply(200, JSON.stringify(mockResponseOpenLibrary));
+
+    nock(WORLDCAT_API_BASE)
+        .get(WORLDCAT_API_BOOK)
+        .socketDelay(10000)
+        .reply(200, JSON.stringify(mockResponseWorldcat));
+
+    isbn.resolve(MOCK_ISBN, function(err, book) {
+      console.log(err);
+      assert.notEqual(err, null);
+      done();
+    })
+  });
 })

--- a/test/spec.js
+++ b/test/spec.js
@@ -269,7 +269,6 @@ describe('ISBN Resolver', function() {
         .reply(200, JSON.stringify(mockResponseWorldcat));
 
     isbn.resolve(MOCK_ISBN, function(err, book) {
-      console.log(err);
       assert.notEqual(err, null);
       done();
     })

--- a/test/spec.js
+++ b/test/spec.js
@@ -197,6 +197,28 @@ describe('ISBN Resolver', function() {
   });
 
   it('should timeout on long connections', function(done) {
+    nock(GOOGLE_BOOKS_API_BASE)
+        .get(GOOGLE_BOOKS_API_BOOK)
+        .socketDelay(10000)
+        .reply(200, JSON.stringify({}));
+
+    nock(OPENLIBRARY_API_BASE)
+        .get(OPENLIBRARY_API_BOOK)
+        .socketDelay(10000)
+        .reply(200, JSON.stringify({}));
+
+    nock(WORLDCAT_API_BASE)
+        .get(WORLDCAT_API_BOOK)
+        .socketDelay(10000)
+        .reply(200, JSON.stringify({}));
+
+    isbn.resolve(MOCK_ISBN, function(err, book) {
+      assert.notEqual(err, null);
+      done();
+    })
+  });
+
+  it('should override default options', function(done) {
     var mockResponseGoogle = {
       totalItems: 1,
       items: [{
@@ -207,69 +229,13 @@ describe('ISBN Resolver', function() {
       }]
     };
 
-    var mockResponseOpenLibrary = {}
-    mockResponseOpenLibrary['ISBN:' + MOCK_ISBN] = {
-      'info_url': 'https://openlibrary.org/books/OL1743093M/Book',
-      'preview_url': 'https://archive.org/details/whatsitallabouta00cain',
-      'thumbnail_url': 'https://covers.openlibrary.org/b/id/6739180-S.jpg',
-      'details': {
-        'number_of_pages': 521,
-        'subtitle': 'an autobiography',
-        'title': 'Book Title',
-        'languages': [
-          {
-            'key': '/languages/eng'
-          }
-        ],
-        'publishers': [
-          'Turtle Bay Books'
-        ],
-        'authors': [
-          {
-            'name': 'Michael Caine',
-            'key': '/authors/OL840869A'
-          }
-        ],
-        'publish_date': '1992',
-      },
-      'preview': 'borrow'
-    };
-
-    var mockResponseWorldcat = {
-      "stat":"ok",
-      "list":[{
-        "url":["http://www.worldcat.org/oclc/249645389?referer=xid"],
-        "publisher":"Turtle Bay Books",
-        "form":["BC", "DA"],
-        "lccn":["2004049981"],
-        "lang":"eng",
-        "city":"Redmond, Wash.",
-        "author":"Steve McConnell.",
-        "ed":"2. ed.",
-        "year":"1992",
-        "isbn":["0735619670"],
-        "title":"Book Title",
-        "oclcnum":["249645389", "301075365", "427465443"]
-      }]
-    };
-
     nock(GOOGLE_BOOKS_API_BASE)
         .get(GOOGLE_BOOKS_API_BOOK)
         .socketDelay(10000)
         .reply(200, JSON.stringify(mockResponseGoogle));
 
-    nock(OPENLIBRARY_API_BASE)
-        .get(OPENLIBRARY_API_BOOK)
-        .socketDelay(10000)
-        .reply(200, JSON.stringify(mockResponseOpenLibrary));
-
-    nock(WORLDCAT_API_BASE)
-        .get(WORLDCAT_API_BOOK)
-        .socketDelay(10000)
-        .reply(200, JSON.stringify(mockResponseWorldcat));
-
-    isbn.resolve(MOCK_ISBN, function(err, book) {
-      assert.notEqual(err, null);
+    isbn.resolve(MOCK_ISBN, { timeout: 15000 }, function(err, book) {
+      assert.equal(err, null);
       done();
     })
   });


### PR DESCRIPTION
This PR adds support for connection timeout, including client-defined overrides. It includes:

- Using `request` module instead of core `http` / `https` API
- Defining a default timeout value (currently 5s)
- Allowing the module called to override `request` options, including `timeout` value
- Tests for the above functionality
