### PR TITLE
Replace request module with axios and add promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ A simple node.js module that **resolves books by ISBN** using multiple services:
 * [Open Library Books API](https://openlibrary.org/dev/docs/api/books)
 * [WorldCat xISBN API](http://xisbn.worldcat.org/xisbnadmin/doc/api.htm)
 
-## Example
+## Examples
+
+### Using a callback
 
 ```javascript
 var isbn = require('node-isbn');
@@ -16,6 +18,32 @@ isbn.resolve('0735619670', function (err, book) {
     } else {
         console.log('Book found %j', book);
     }
+});
+```
+
+### Setting a timeout
+
+```javascript
+var isbn = require('node-isbn');
+
+isbn.resolve('0735619670', { timeout: 15000 }, function (err, book) {
+    if (err) {
+        console.log('Book not found', err);
+    } else {
+        console.log('Book found %j', book);
+    }
+});
+```
+
+### Using a promise
+
+```javascript
+var isbn = require('node-isbn');
+
+isbn.resolve('0735619670').then(function (book) {
+    console.log('Book found %j', book);
+}).catch(function (err) {
+    console.log('Book not found', err);
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Find books by ISBN",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/spec"
+    "test": "mocha test/spec",
+    "testDebug": "mocha --inspect-brk test/spec"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,6 @@
     "nock": "^9.0.13"
   },
   "dependencies": {
-    "request": "^2.81.0"
+    "axios": "^0.17.1"
   }
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -17,226 +17,474 @@ var WORLDCAT_API_BASE = 'http://xisbn.worldcat.org';
 var WORLDCAT_API_BOOK = '/webservices/xid/isbn/' + MOCK_ISBN + '?method=getMetadata&fl=*&format=json';
 
 describe('ISBN Resolver', function() {
-  it('should resolve a valid ISBN with Google', function(done) {
-    var mockResponseGoogle = {
-      totalItems: 1,
-      items: [{
-        'volumeInfo': {
-          'title': 'Code Complete',
-          'authors': ['Steve McConnell']
-        }
-      }]
-    };
-
-    nock(GOOGLE_BOOKS_API_BASE)
-        .get(GOOGLE_BOOKS_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseGoogle));
-
-    isbn.resolve(MOCK_ISBN, function(err, book) {
-      assert.equal(err, null);
-      assert.deepEqual(book, mockResponseGoogle.items[0].volumeInfo);
-      done();
-    })
-  });
-
-  it('should resolve a valid ISBN with Open Library', function(done) {
-    var mockResponseGoogle = {
-      kind: 'books#volumes',
-      totalItems: 0
-    };
-
-    var mockResponseOpenLibrary = {}
-    mockResponseOpenLibrary['ISBN:' + MOCK_ISBN] = {
-      'info_url': 'https://openlibrary.org/books/OL1743093M/Book',
-      'preview_url': 'https://archive.org/details/whatsitallabouta00cain',
-      'thumbnail_url': 'https://covers.openlibrary.org/b/id/6739180-S.jpg',
-      'details': {
-        'number_of_pages': 521,
-        'subtitle': 'an autobiography',
-        'title': 'Book Title',
-        'languages': [
-          {
-            'key': '/languages/eng'
+  describe('using callback', function() {
+    it('should resolve a valid ISBN with Google', function(done) {
+      var mockResponseGoogle = {
+        totalItems: 1,
+        items: [{
+          'volumeInfo': {
+            'title': 'Code Complete',
+            'authors': ['Steve McConnell']
           }
-        ],
-        'publishers': [
-          'Turtle Bay Books'
-        ],
-        'authors': [
-          {
-            'name': 'Michael Caine',
-            'key': '/authors/OL840869A'
+        }]
+      };
+
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseGoogle));
+
+      isbn.resolve(MOCK_ISBN, function(err, book) {
+        assert.equal(err, null);
+        assert.deepEqual(book, mockResponseGoogle.items[0].volumeInfo);
+        done();
+      })
+    });
+
+    it('should resolve a valid ISBN with Open Library', function(done) {
+      var mockResponseGoogle = {
+        kind: 'books#volumes',
+        totalItems: 0
+      };
+
+      var mockResponseOpenLibrary = {}
+      mockResponseOpenLibrary['ISBN:' + MOCK_ISBN] = {
+        'info_url': 'https://openlibrary.org/books/OL1743093M/Book',
+        'preview_url': 'https://archive.org/details/whatsitallabouta00cain',
+        'thumbnail_url': 'https://covers.openlibrary.org/b/id/6739180-S.jpg',
+        'details': {
+          'number_of_pages': 521,
+          'subtitle': 'an autobiography',
+          'title': 'Book Title',
+          'languages': [
+            {
+              'key': '/languages/eng'
+            }
+          ],
+          'publishers': [
+            'Turtle Bay Books'
+          ],
+          'authors': [
+            {
+              'name': 'Michael Caine',
+              'key': '/authors/OL840869A'
+            }
+          ],
+          'publish_date': '1992',
+        },
+        'preview': 'borrow'
+      };
+
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseGoogle));
+
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseOpenLibrary));
+
+      isbn.resolve(MOCK_ISBN, function(err, book) {
+        assert.equal(err, null);
+        assert.equal(book.title, 'Book Title');
+        assert.equal(book.publisher, 'Turtle Bay Books');
+        assert.equal(book.publishedDate, '1992');
+        assert.equal(book.pageCount, 521);
+        assert.equal(book.language, 'en');
+        done();
+      })
+    });
+
+    it('should resolve a valid ISBN with Worldcat', function(done) {
+      var mockResponseGoogle = {
+        kind: 'books#volumes',
+        totalItems: 0
+      };
+
+      var mockResponseOpenLibrary = {};
+
+      var mockResponseWorldcat = {
+        "stat":"ok",
+        "list":[{
+          "url":["http://www.worldcat.org/oclc/249645389?referer=xid"],
+          "publisher":"Turtle Bay Books",
+          "form":["BC", "DA"],
+          "lccn":["2004049981"],
+          "lang":"eng",
+          "city":"Redmond, Wash.",
+          "author":"Steve McConnell.",
+          "ed":"2. ed.",
+          "year":"1992",
+          "isbn":["0735619670"],
+          "title":"Book Title",
+          "oclcnum":["249645389", "301075365", "427465443"]
+        }]
+      };
+
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseGoogle));
+
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseOpenLibrary));
+
+      nock(WORLDCAT_API_BASE)
+          .get(WORLDCAT_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseWorldcat));
+
+      isbn.resolve(MOCK_ISBN, function(err, book) {
+        assert.equal(err, null);
+        assert.equal(book.title, 'Book Title');
+        assert.equal(book.publisher, 'Turtle Bay Books');
+        assert.equal(book.publishedDate, '1992');
+        assert.equal(book.language, 'en');
+        done();
+      })
+    });
+
+    it('should return an error if no book is found', function(done) {
+      var mockResponseGoogle = {
+        kind: 'books#volumes',
+        totalItems: 0
+      };
+
+      var mockResponseOpenLibrary = {};
+
+      var mockResponseWorldcat = {'stat': 'invalidId'};
+
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseGoogle));
+
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseOpenLibrary));
+
+      nock(WORLDCAT_API_BASE)
+          .get(WORLDCAT_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseWorldcat));
+
+      isbn.resolve(MOCK_ISBN, function(err, book) {
+        assert.notEqual(err, null);
+        done();
+      })
+    });
+
+    it('should return an error if external endpoints are not reachable', function(done) {
+      nock.disableNetConnect();
+
+      isbn.resolve(MOCK_ISBN, function(err, book) {
+        assert.notEqual(err, null);
+        done();
+      })
+    });
+
+    it('should return an error if external endpoints return a HTTP error', function(done) {
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(500);
+
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .reply(500);
+
+      nock(WORLDCAT_API_BASE)
+          .get(WORLDCAT_API_BOOK)
+          .reply(500);
+
+      isbn.resolve(MOCK_ISBN, function(err, book) {
+        assert.notEqual(err, null);
+        done();
+      })
+    });
+
+    it('should timeout on long connections', function(done) {
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .socketDelay(10000)
+          .reply(200, JSON.stringify({}));
+
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .socketDelay(10000)
+          .reply(200, JSON.stringify({}));
+
+      nock(WORLDCAT_API_BASE)
+          .get(WORLDCAT_API_BOOK)
+          .socketDelay(10000)
+          .reply(200, JSON.stringify({}));
+
+      isbn.resolve(MOCK_ISBN, function(err, book) {
+        assert.notEqual(err, null);
+        done();
+      })
+    });
+
+    it('should override default options', function(done) {
+      var mockResponseGoogle = {
+        totalItems: 1,
+        items: [{
+          'volumeInfo': {
+            'title': 'Code Complete',
+            'authors': ['Steve McConnell']
           }
-        ],
-        'publish_date': '1992',
-      },
-      'preview': 'borrow'
-    };
+        }]
+      };
 
-    nock(GOOGLE_BOOKS_API_BASE)
-        .get(GOOGLE_BOOKS_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseGoogle));
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .socketDelay(10000)
+          .reply(200, JSON.stringify(mockResponseGoogle));
 
-    nock(OPENLIBRARY_API_BASE)
-        .get(OPENLIBRARY_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseOpenLibrary));
-
-    isbn.resolve(MOCK_ISBN, function(err, book) {
-      assert.equal(err, null);
-      assert.equal(book.title, 'Book Title');
-      assert.equal(book.publisher, 'Turtle Bay Books');
-      assert.equal(book.publishedDate, '1992');
-      assert.equal(book.pageCount, 521);
-      assert.equal(book.language, 'en');
-      done();
-    })
+      isbn.resolve(MOCK_ISBN, { timeout: 15000 }, function(err, book) {
+        assert.equal(err, null);
+        done();
+      })
+    });
   });
 
-  it('should resolve a valid ISBN with Worldcat', function(done) {
-    var mockResponseGoogle = {
-      kind: 'books#volumes',
-      totalItems: 0
-    };
+  describe('using promise', function() {
+    it('should resolve a valid ISBN with Google', function(done) {
+      var mockResponseGoogle = {
+        totalItems: 1,
+        items: [{
+          'volumeInfo': {
+            'title': 'Code Complete',
+            'authors': ['Steve McConnell']
+          }
+        }]
+      };
 
-    var mockResponseOpenLibrary = {};
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseGoogle));
 
-    var mockResponseWorldcat = {
-      "stat":"ok",
-      "list":[{
-        "url":["http://www.worldcat.org/oclc/249645389?referer=xid"],
-        "publisher":"Turtle Bay Books",
-        "form":["BC", "DA"],
-        "lccn":["2004049981"],
-        "lang":"eng",
-        "city":"Redmond, Wash.",
-        "author":"Steve McConnell.",
-        "ed":"2. ed.",
-        "year":"1992",
-        "isbn":["0735619670"],
-        "title":"Book Title",
-        "oclcnum":["249645389", "301075365", "427465443"]
-      }]
-    };
+      isbn.resolve(MOCK_ISBN)
+      .then(function(book) {
+        assert.deepEqual(book, mockResponseGoogle.items[0].volumeInfo);
+        done();
+      })
+      .catch(done);
+    });
 
-    nock(GOOGLE_BOOKS_API_BASE)
-        .get(GOOGLE_BOOKS_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseGoogle));
+    it('should resolve a valid ISBN with Open Library', function(done) {
+      var mockResponseGoogle = {
+        kind: 'books#volumes',
+        totalItems: 0
+      };
 
-    nock(OPENLIBRARY_API_BASE)
-        .get(OPENLIBRARY_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseOpenLibrary));
+      var mockResponseOpenLibrary = {}
+      mockResponseOpenLibrary['ISBN:' + MOCK_ISBN] = {
+        'info_url': 'https://openlibrary.org/books/OL1743093M/Book',
+        'preview_url': 'https://archive.org/details/whatsitallabouta00cain',
+        'thumbnail_url': 'https://covers.openlibrary.org/b/id/6739180-S.jpg',
+        'details': {
+          'number_of_pages': 521,
+          'subtitle': 'an autobiography',
+          'title': 'Book Title',
+          'languages': [
+            {
+              'key': '/languages/eng'
+            }
+          ],
+          'publishers': [
+            'Turtle Bay Books'
+          ],
+          'authors': [
+            {
+              'name': 'Michael Caine',
+              'key': '/authors/OL840869A'
+            }
+          ],
+          'publish_date': '1992',
+        },
+        'preview': 'borrow'
+      };
 
-    nock(WORLDCAT_API_BASE)
-        .get(WORLDCAT_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseWorldcat));
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseGoogle));
 
-    isbn.resolve(MOCK_ISBN, function(err, book) {
-      assert.equal(err, null);
-      assert.equal(book.title, 'Book Title');
-      assert.equal(book.publisher, 'Turtle Bay Books');
-      assert.equal(book.publishedDate, '1992');
-      assert.equal(book.language, 'en');
-      done();
-    })
-  });
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseOpenLibrary));
 
-  it('should return an error if no book is found', function(done) {
-    var mockResponseGoogle = {
-      kind: 'books#volumes',
-      totalItems: 0
-    };
+      isbn.resolve(MOCK_ISBN)
+      .then(function(book) {
+        assert.equal(book.title, 'Book Title');
+        assert.equal(book.publisher, 'Turtle Bay Books');
+        assert.equal(book.publishedDate, '1992');
+        assert.equal(book.pageCount, 521);
+        assert.equal(book.language, 'en');
+        done();
+      })
+      .catch(done);
+    });
 
-    var mockResponseOpenLibrary = {};
+    it('should resolve a valid ISBN with Worldcat', function(done) {
+      var mockResponseGoogle = {
+        kind: 'books#volumes',
+        totalItems: 0
+      };
 
-    var mockResponseWorldcat = {'stat': 'invalidId'};
+      var mockResponseOpenLibrary = {};
 
-    nock(GOOGLE_BOOKS_API_BASE)
-        .get(GOOGLE_BOOKS_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseGoogle));
+      var mockResponseWorldcat = {
+        "stat":"ok",
+        "list":[{
+          "url":["http://www.worldcat.org/oclc/249645389?referer=xid"],
+          "publisher":"Turtle Bay Books",
+          "form":["BC", "DA"],
+          "lccn":["2004049981"],
+          "lang":"eng",
+          "city":"Redmond, Wash.",
+          "author":"Steve McConnell.",
+          "ed":"2. ed.",
+          "year":"1992",
+          "isbn":["0735619670"],
+          "title":"Book Title",
+          "oclcnum":["249645389", "301075365", "427465443"]
+        }]
+      };
 
-    nock(OPENLIBRARY_API_BASE)
-        .get(OPENLIBRARY_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseOpenLibrary));
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseGoogle));
 
-    nock(WORLDCAT_API_BASE)
-        .get(WORLDCAT_API_BOOK)
-        .reply(200, JSON.stringify(mockResponseWorldcat));
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseOpenLibrary));
 
-    isbn.resolve(MOCK_ISBN, function(err, book) {
-      assert.notEqual(err, null);
-      done();
-    })
-  });
+      nock(WORLDCAT_API_BASE)
+          .get(WORLDCAT_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseWorldcat));
 
-  it('should return an error if external endpoints are not reachable', function(done) {
-    nock.disableNetConnect();
+      isbn.resolve(MOCK_ISBN)
+      .then(function(book) {
+        assert.equal(book.title, 'Book Title');
+        assert.equal(book.publisher, 'Turtle Bay Books');
+        assert.equal(book.publishedDate, '1992');
+        assert.equal(book.language, 'en');
+        done();
+      })
+      .catch(done);
+    });
 
-    isbn.resolve(MOCK_ISBN, function(err, book) {
-      assert.notEqual(err, null);
-      done();
-    })
-  });
+    it('should return an error if no book is found', function(done) {
+      var mockResponseGoogle = {
+        kind: 'books#volumes',
+        totalItems: 0
+      };
 
-  it('should return an error if external endpoints return a HTTP error', function(done) {
-    nock(GOOGLE_BOOKS_API_BASE)
-        .get(GOOGLE_BOOKS_API_BOOK)
-        .reply(500);
+      var mockResponseOpenLibrary = {};
 
-    nock(OPENLIBRARY_API_BASE)
-        .get(OPENLIBRARY_API_BOOK)
-        .reply(500);
+      var mockResponseWorldcat = {'stat': 'invalidId'};
 
-    nock(WORLDCAT_API_BASE)
-        .get(WORLDCAT_API_BOOK)
-        .reply(500);
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseGoogle));
 
-    isbn.resolve(MOCK_ISBN, function(err, book) {
-      assert.notEqual(err, null);
-      done();
-    })
-  });
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseOpenLibrary));
 
-  it('should timeout on long connections', function(done) {
-    nock(GOOGLE_BOOKS_API_BASE)
-        .get(GOOGLE_BOOKS_API_BOOK)
-        .socketDelay(10000)
-        .reply(200, JSON.stringify({}));
+      nock(WORLDCAT_API_BASE)
+          .get(WORLDCAT_API_BOOK)
+          .reply(200, JSON.stringify(mockResponseWorldcat));
 
-    nock(OPENLIBRARY_API_BASE)
-        .get(OPENLIBRARY_API_BOOK)
-        .socketDelay(10000)
-        .reply(200, JSON.stringify({}));
+      isbn.resolve(MOCK_ISBN)
+      .then(function(book) {
+        done(new Error('resolve succeeded when failure expected'));
+      })
+      .catch(function (err) {
+        assert.notEqual(err, null);
+        done();
+      });
+    });
 
-    nock(WORLDCAT_API_BASE)
-        .get(WORLDCAT_API_BOOK)
-        .socketDelay(10000)
-        .reply(200, JSON.stringify({}));
+    it('should return an error if external endpoints are not reachable', function(done) {
+      nock.disableNetConnect();
 
-    isbn.resolve(MOCK_ISBN, function(err, book) {
-      assert.notEqual(err, null);
-      done();
-    })
-  });
+      isbn.resolve(MOCK_ISBN)
+      .then(function(book) {
+        done(new Error('resolve succeeded when failure expected'));
+      })
+      .catch(function (err) {
+        assert.notEqual(err, null);
+        done();
+      });
+    });
 
-  it('should override default options', function(done) {
-    var mockResponseGoogle = {
-      totalItems: 1,
-      items: [{
-        'volumeInfo': {
-          'title': 'Code Complete',
-          'authors': ['Steve McConnell']
-        }
-      }]
-    };
+    it('should return an error if external endpoints return a HTTP error', function(done) {
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .reply(500);
 
-    nock(GOOGLE_BOOKS_API_BASE)
-        .get(GOOGLE_BOOKS_API_BOOK)
-        .socketDelay(10000)
-        .reply(200, JSON.stringify(mockResponseGoogle));
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .reply(500);
 
-    isbn.resolve(MOCK_ISBN, { timeout: 15000 }, function(err, book) {
-      assert.equal(err, null);
-      done();
-    })
-  });
+      nock(WORLDCAT_API_BASE)
+          .get(WORLDCAT_API_BOOK)
+          .reply(500);
+
+      isbn.resolve(MOCK_ISBN)
+      .then(function(book) {
+        done(new Error('resolve succeeded when failure expected'));
+      })
+      .catch(function (err) {
+        assert.notEqual(err, null);
+        done();
+      });
+    });
+
+    it('should timeout on long connections', function(done) {
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .socketDelay(10000)
+          .reply(200, JSON.stringify({}));
+
+      nock(OPENLIBRARY_API_BASE)
+          .get(OPENLIBRARY_API_BOOK)
+          .socketDelay(10000)
+          .reply(200, JSON.stringify({}));
+
+      nock(WORLDCAT_API_BASE)
+          .get(WORLDCAT_API_BOOK)
+          .socketDelay(10000)
+          .reply(200, JSON.stringify({}));
+
+      isbn.resolve(MOCK_ISBN)
+      .then(function(book) {
+        done(new Error('resolve succeeded when failure expected'));
+      })
+      .catch(function (err) {
+        assert.notEqual(err, null);
+        done();
+      });
+    });
+
+    it('should override default options', function(done) {
+      var mockResponseGoogle = {
+        totalItems: 1,
+        items: [{
+          'volumeInfo': {
+            'title': 'Code Complete',
+            'authors': ['Steve McConnell']
+          }
+        }]
+      };
+
+      nock(GOOGLE_BOOKS_API_BASE)
+          .get(GOOGLE_BOOKS_API_BOOK)
+          .socketDelay(10000)
+          .reply(200, JSON.stringify(mockResponseGoogle));
+
+      isbn.resolve(MOCK_ISBN, { timeout: 15000 })
+      .then(function(book) {
+        assert.equal(book.title, 'Code Complete');
+        done();
+      })
+      .catch(done);
+    });
+  });  
 })


### PR DESCRIPTION
To better allow node-isbn to be used in a Webpack build, this PR replaces the `request` module with the `axios` request module. 

Since `axios` is a Promise-based HTTP request module, it seemed logical to surface Promise-aware functionality to `node-isbn` at the same time. The callback-based API is unchanged.

New tests and updated documentation are provided.

Rationale: The `request` module has dependencies on Node-specific `fs`, `net`, and `tls` modules which must be replaced with empty objects in webpack.config.js in order for Webpack to build successfully. Even so, `request`'s larger number of dependencies results in a much bigger bundle than a similar build using `axios` instead. In my case, the unminified bundle went from 2.1MB down to 53.7kb.

Pros:
* Enables easier use of the module on the browser
* Smaller resulting Webpack bundle
* Support for Promises

Cons:
* Possible breakage of options API, as `axios` does not support all the same options as `request`. The timeout option is, however, common to both packages.
